### PR TITLE
Support OnDemand 2.0 and Puppet 7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,9 +6,6 @@ on:
       - main
       - master
   pull_request:
-    branches:
-      - main
-      - master
 
 jobs:
   unit:
@@ -24,6 +21,10 @@ jobs:
             allow_failure: false
           - ruby: 2.5.7
             puppet: 6
+            fixtures: .fixtures.yml
+            allow_failure: false
+          - ruby: 2.7.0
+            puppet: 7
             fixtures: .fixtures.yml
             allow_failure: false
     env:
@@ -55,6 +56,7 @@ jobs:
         puppet:
           - "puppet5"
           - "puppet6"
+          - "puppet7"
     env:
       BUNDLE_WITHOUT: development:release
       BEAKER_debug: true

--- a/.sync.yml
+++ b/.sync.yml
@@ -23,3 +23,5 @@ spec/acceptance/nodesets/ubuntu-1604.yml:
   delete: true
 spec/acceptance/nodesets/ubuntu-1804.yml:
   delete: true
+spec/acceptance/nodesets/ubuntu-2004.yml:
+  delete: true

--- a/Gemfile
+++ b/Gemfile
@@ -32,8 +32,8 @@ group :development do
   gem "github_changelog_generator",                              require: false
 end
 group :system_tests do
-  gem "puppet-module-posix-system-r#{minor_version}",                            require: false, platforms: [:ruby]
-  gem "puppet-module-win-system-r#{minor_version}",                              require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-posix-system-r#{minor_version}", '~> 0.5',                  require: false, platforms: [:ruby]
+  gem "puppet-module-win-system-r#{minor_version}", '~> 0.5',                    require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4.0')
   gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')
   gem "beaker-pe",                                                               require: false

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Manage [Open OnDemand](http://openondemand.org/) installation and configuration.
 
 The following are the versions of this module and the supported versions of Open OnDemand:
 
-* Module >= 1.0.0 supports Open OnDemand >= 1.8
+* Module 2.x supports Open OnDemand 2.x
+* Module 1.x supports Open OnDemand 1.18.x
 * Module <= 0.12.0 supports Open OnDemand <= 1.7
 
 
@@ -28,15 +29,15 @@ The following are the versions of this module and the supported versions of Open
 All configuration can be done through the `openondemand` class. Example configurations will be done in Hiera format.
 
 ```puppet
-include ::openondemand
+include openondemand
 ```
 
-Install specific versions of OnDemand from 1.6 repo with OpenID Connect support.
+Install specific versions of OnDemand from 2.0 repo with OpenID Connect support.
 
 ```yaml
-openondemand::repo_release: '1.8'
-openondemand::ondemand_package_ensure: "1.8.5-1.el7"
-openondemand::mod_auth_openidc_ensure: "2.3.11-1.el7"
+openondemand::repo_release: '2.0'
+openondemand::ondemand_package_ensure: "2.0.0-1.el7"
+openondemand::mod_auth_openidc_ensure: "2.4.5-1.el7"
 ```
 
 Configure OnDemand SSL certs
@@ -105,7 +106,7 @@ openondemand::servername: ondemand.osc.edu
 openondemand::auth_type: 'openid-connect'
 openondemand::auth_configs:
   - 'Require valid-user'
-openondemand::user_map_cmd: /opt/ood/ood_auth_map/bin/ood_auth_map.regex
+openondemand::user_map_match: '.*'
 openondemand::logout_redirect: "/oidc?logout=https%3A%2F%2F%{lookup('openondemand::servername')}"
 openondemand::oidc_uri: '/oidc'
 openondemand::oidc_provider_metadata_url: 'https://idp.osc.edu/auth/realms/osc/.well-known/openid-configuration'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,6 +88,10 @@
 #   ood_portal.yml pun_socket_root
 # @param pun_max_retries
 #   ood_portal.yml pun_max_retries
+# @param pun_pre_hook_root_cmd
+#   ood_portal.yml pun_pre_hook_root_cmd
+# @param pun_pre_hook_exports
+#   ood_porta.yml pun_pre_hook_exports
 # @param oidc_uri
 #   ood_portal.yml oidc_uri
 # @param oidc_discover_uri
@@ -228,6 +232,8 @@ class openondemand (
   String $pun_uri = '/pun',
   String $pun_socket_root = '/var/run/ondemand-nginx',
   Integer $pun_max_retries = 5,
+  Optional[Stdlib::Absolutepath] $pun_pre_hook_root_cmd = undef,
+  Optional[String] $pun_pre_hook_exports = undef,
   Optional[String] $oidc_uri = undef,
   Optional[String] $oidc_discover_uri = undef,
   Optional[String] $oidc_discover_root = undef,
@@ -408,6 +414,8 @@ class openondemand (
     'pun_uri'                          => $pun_uri,
     'pun_socket_root'                  => $pun_socket_root,
     'pun_max_retries'                  => $pun_max_retries,
+    'pun_pre_hook_root_cmd'            => $pun_pre_hook_root_cmd,
+    'pun_pre_hook_exports'             => $pun_pre_hook_exports,
     'oidc_uri'                         => $oidc_uri,
     'oidc_discover_uri'                => $oidc_discover_uri,
     'oidc_discover_root'               => $oidc_discover_root,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,8 @@
 #   ood_portal.yml lua_root
 # @param lua_log_level
 #   ood_portal.yml lua_log_level
+# @param user_map_match
+#   ood_portal.yml user_map_match
 # @param user_map_cmd
 #   ood_portal.yml user_map_cmd
 # @param user_env
@@ -207,7 +209,8 @@ class openondemand (
   Boolean $security_strict_transport = true,
   String $lua_root = '/opt/ood/mod_ood_proxy/lib',
   Optional[String] $lua_log_level = undef,
-  String $user_map_cmd  = '/opt/ood/ood_auth_map/bin/ood_auth_map.regex',
+  String $user_map_match = '.*',
+  Optional[String] $user_map_cmd  = undef,
   Optional[String] $user_env = undef,
   Optional[String] $map_fail_uri = undef,
   Enum['CAS', 'openid-connect', 'shibboleth', 'dex'] $auth_type = 'dex',
@@ -386,6 +389,7 @@ class openondemand (
     'security_strict_transport'        => $security_strict_transport,
     'lua_root'                         => $lua_root,
     'lua_log_level'                    => $lua_log_level,
+    'user_map_match'                   => $user_map_match,
     'user_map_cmd'                     => $user_map_cmd,
     'user_env'                         => $user_env,
     'map_fail_uri'                     => $map_fail_uri,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -197,7 +197,7 @@ class openondemand (
 
   # Apache
   Boolean $declare_apache = true,
-  String $apache_scls = 'httpd24 rh-ruby25',
+  String $apache_scls = 'httpd24 rh-ruby27',
 
   # ood_portal.yml
   Variant[Array, String, Undef] $listen_addr_port = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,8 +8,8 @@
 #   The URL for OnDemand repo GPG key
 # @param repo_priority
 #   The priority of the OnDemand repo
-# @param manage_scl
-#   Boolean that determines if managing SCL
+# @param manage_dependency_repos
+#   Boolean that determines if managing repos for package dependencies
 # @param selinux
 #   Boolean that determines if adding SELinux support
 # @param ondemand_package_ensure
@@ -186,7 +186,7 @@ class openondemand (
   Variant[Stdlib::HTTPSUrl, Stdlib::HTTPUrl, Stdlib::Absolutepath]
     $repo_gpgkey = 'https://yum.osc.edu/ondemand/RPM-GPG-KEY-ondemand',
   Integer[1,99] $repo_priority = 99,
-  Boolean $manage_scl = true,
+  Boolean $manage_dependency_repos = true,
 
   # packages
   Boolean $selinux = false,

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -14,7 +14,7 @@ class openondemand::repo {
     priority        => $openondemand::repo_priority,
   }
 
-  if versioncmp($openondemand::osmajor, '7') <= 0 and $openondemand::manage_scl {
+  if versioncmp($openondemand::osmajor, '7') <= 0 and $openondemand::manage_dependency_repos {
     if $facts['os']['name'] == 'CentOS' and versioncmp($openondemand::osmajor, '7') == 0 {
       file { '/etc/yum.repos.d/ondemand-centos-scl.repo':
         ensure => 'absent',
@@ -35,6 +35,29 @@ class openondemand::repo {
       default: {
         # Do nothing
       }
+    }
+  }
+
+  if versioncmp($openondemand::osmajor, '8') >= 0 and $openondemand::manage_dependency_repos {
+    package { 'nodejs:10':
+      ensure   => 'disabled',
+      provider => 'dnfmodule',
+      before   => Package['nodejs:12'],
+    }
+    package { 'nodejs:12':
+      ensure      => 'present',
+      enable_only => true,
+      provider    => 'dnfmodule',
+    }
+    package { 'ruby:2.5':
+      ensure   => 'disabled',
+      provider => 'dnfmodule',
+      before   => Package['ruby:2.7'],
+    }
+    package { 'ruby:2.7':
+      ensure      => 'present',
+      enable_only => true,
+      provider    => 'dnfmodule',
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -70,7 +70,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.0.0 < 7.0.0"
+      "version_requirement": ">= 5.0.0 < 8.0.0"
     }
   ],
   "tags": [
@@ -80,5 +80,5 @@
   ],
   "pdk-version": "1.17.0",
   "template-url": "https://github.com/treydock/pdk-templates.git#master",
-  "template-ref": "heads/master-0-g553c432"
+  "template-ref": "heads/master-0-ge286426"
 }

--- a/spec/acceptance/nodesets/centos-7.yml
+++ b/spec/acceptance/nodesets/centos-7.yml
@@ -10,6 +10,10 @@ HOSTS:
       - '/usr/sbin/init'
     docker_image_commands:
       - 'yum install -y wget which cronie iproute initscripts'
+    docker_env:
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US.UTF-8
+      - LC_ALL=en_US.UTF-8
     docker_container_name: 'openondemand-el7'
 CONFIG:
   log_level: debug

--- a/spec/acceptance/nodesets/centos-8.yml
+++ b/spec/acceptance/nodesets/centos-8.yml
@@ -11,7 +11,11 @@ HOSTS:
     docker_image_commands:
       - 'yum install -y dnf-utils'
       - 'dnf config-manager --set-enabled powertools'
-      - 'yum install -y wget which cronie iproute initscripts'
+      - 'yum install -y wget which cronie iproute initscripts langpacks-en glibc-all-langpacks'
+    docker_env:
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US.UTF-8
+      - LC_ALL=en_US.UTF-8
     docker_container_name: 'openondemand-el8'
 CONFIG:
   log_level: debug

--- a/spec/shared_examples/repo.rb
+++ b/spec/shared_examples/repo.rb
@@ -11,6 +11,8 @@ shared_examples 'openondemand::repo' do |facts|
   end
 
   if facts[:os]['release']['major'].to_i == 7
+    it { is_expected.not_to contain_exec('dnf makecache ondemand-web') }
+
     if facts[:os]['name'] == 'CentOS'
       it { is_expected.to contain_file('/etc/yum.repos.d/ondemand-centos-scl.repo').with_ensure('absent') }
     else
@@ -29,29 +31,29 @@ shared_examples 'openondemand::repo' do |facts|
 
   if facts[:os]['release']['major'].to_i == 8
     it do
-      is_expected.to contain_package('nodejs:10').with(
-        ensure: 'disabled',
-        provider: 'dnfmodule',
-        before: 'Package[nodejs:12]',
+      is_expected.to contain_exec('dnf makecache ondemand-web').with(
+        path: '/usr/bin:/bin:/usr/sbin:/sbin',
+        command: "dnf -q makecache -y --disablerepo='*' --enablerepo='ondemand-web'",
+        refreshonly: 'true',
+        subscribe: 'Yumrepo[ondemand-web]',
       )
     end
+
     it do
-      is_expected.to contain_package('nodejs:12').with(
-        ensure: 'present',
+      is_expected.to contain_exec('dnf makecache ondemand-web').that_comes_before('Package[nodejs]')
+      is_expected.to contain_exec('dnf makecache ondemand-web').that_comes_before('Package[ruby]')
+    end
+
+    it do
+      is_expected.to contain_package('nodejs').with(
+        ensure: '12',
         enable_only: 'true',
         provider: 'dnfmodule',
       )
     end
     it do
-      is_expected.to contain_package('ruby:2.5').with(
-        ensure: 'disabled',
-        provider: 'dnfmodule',
-        before: 'Package[ruby:2.7]',
-      )
-    end
-    it do
-      is_expected.to contain_package('ruby:2.7').with(
-        ensure: 'present',
+      is_expected.to contain_package('ruby').with(
+        ensure: '2.7',
         enable_only: 'true',
         provider: 'dnfmodule',
       )

--- a/spec/shared_examples/repo.rb
+++ b/spec/shared_examples/repo.rb
@@ -23,10 +23,43 @@ shared_examples 'openondemand::repo' do |facts|
     when 'CentOS'
       it { is_expected.to contain_package('centos-release-scl').with_ensure('installed') }
     end
+    it { is_expected.not_to contain_package('nodejs:12') }
+    it { is_expected.not_to contain_package('ruby:2.7') }
   end
 
-  context 'when manage_scl => false' do
-    let(:params) { { manage_scl: false } }
+  if facts[:os]['release']['major'].to_i == 8
+    it do
+      is_expected.to contain_package('nodejs:10').with(
+        ensure: 'disabled',
+        provider: 'dnfmodule',
+        before: 'Package[nodejs:12]',
+      )
+    end
+    it do
+      is_expected.to contain_package('nodejs:12').with(
+        ensure: 'present',
+        enable_only: 'true',
+        provider: 'dnfmodule',
+      )
+    end
+    it do
+      is_expected.to contain_package('ruby:2.5').with(
+        ensure: 'disabled',
+        provider: 'dnfmodule',
+        before: 'Package[ruby:2.7]',
+      )
+    end
+    it do
+      is_expected.to contain_package('ruby:2.7').with(
+        ensure: 'present',
+        enable_only: 'true',
+        provider: 'dnfmodule',
+      )
+    end
+  end
+
+  context 'when manage_dependency_repos => false' do
+    let(:params) { { manage_dependency_repos: false } }
 
     it { is_expected.not_to contain_file('/etc/yum.repos.d/ondemand-centos-scl.repo') }
     it { is_expected.not_to contain_rh_repo("rhel-server-rhscl-#{facts[:os]['release']['major']}-rpms") }


### PR DESCRIPTION
Breaking changes:

* Rename manage_scl parameter to manage_dependency_repos
* Only support OnDemand 2.x

Changes

* Add user_map_match parameter, make default over user_map_cmd 