### PR TITLE
Allow arbitrary string for auth_type

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -257,7 +257,7 @@ class openondemand (
   Optional[String] $user_map_cmd  = undef,
   Optional[String] $user_env = undef,
   Optional[String] $map_fail_uri = undef,
-  Enum['CAS', 'openid-connect', 'shibboleth', 'dex'] $auth_type = 'dex',
+  Variant[Enum['CAS', 'openid-connect', 'shibboleth', 'dex'], String] $auth_type = 'dex',
   Optional[Array] $auth_configs = undef,
   String $root_uri = '/pun/sys/dashboard',
   Optional[Struct[{url => String, id => String}]] $analytics = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -257,7 +257,7 @@ class openondemand (
   Optional[String] $user_map_cmd  = undef,
   Optional[String] $user_env = undef,
   Optional[String] $map_fail_uri = undef,
-  Variant[Enum['CAS', 'openid-connect', 'shibboleth', 'dex'], String] $auth_type = 'dex',
+  Variant[Enum['CAS', 'openid-connect', 'shibboleth', 'dex'], String[1]] $auth_type = 'dex',
   Optional[Array] $auth_configs = undef,
   String $root_uri = '/pun/sys/dashboard',
   Optional[Struct[{url => String, id => String}]] $analytics = undef,


### PR DESCRIPTION
For sites that use an AuthType that is not a member of the Enum, it would be useful if this parameter also accepted any string. I left the Enum as a variant as it might be a useful hint for the most commonly used types.