### PR TITLE
Adding proxy for ondemand repo.

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -58,6 +58,7 @@ The following parameters are available in the `openondemand` class:
 * [`repo_release`](#repo_release)
 * [`repo_baseurl_prefix`](#repo_baseurl_prefix)
 * [`repo_gpgkey`](#repo_gpgkey)
+* [`repo_proxy`](#repo_proxy)
 * [`repo_priority`](#repo_priority)
 * [`repo_exclude`](#repo_exclude)
 * [`manage_dependency_repos`](#manage_dependency_repos)
@@ -186,6 +187,14 @@ Data type: `Variant[Stdlib::HTTPSUrl, Stdlib::HTTPUrl, Stdlib::Absolutepath]`
 The URL for OnDemand repo GPG key
 
 Default value: `'https://yum.osc.edu/ondemand/RPM-GPG-KEY-ondemand'`
+
+##### <a name="repo_proxy"></a>`repo_proxy`
+
+Data type: `String`
+
+The URL for OnDemand repo proxy
+
+Default value: `'_none_'`
 
 ##### <a name="repo_priority"></a>`repo_priority`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,8 @@
 #   The baseurl prefix for OnDemand repo
 # @param repo_gpgkey
 #   The URL for OnDemand repo GPG key
+# @param repo_proxy
+#   The URL for proxy for OnDemand repo
 # @param repo_priority
 #   The priority of the OnDemand repo
 # @param repo_exclude
@@ -225,6 +227,7 @@ class openondemand (
     $repo_baseurl_prefix = 'https://yum.osc.edu/ondemand',
   Variant[Stdlib::HTTPSUrl, Stdlib::HTTPUrl, Stdlib::Absolutepath]
     $repo_gpgkey = 'https://yum.osc.edu/ondemand/RPM-GPG-KEY-ondemand',
+  String $repo_proxy = '_none_',
   Integer[1,99] $repo_priority = 99,
   String $repo_exclude = 'absent',
   Boolean $manage_dependency_repos = true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -235,7 +235,7 @@ class openondemand (
   $repo_baseurl_prefix = 'https://yum.osc.edu/ondemand',
   Variant[Stdlib::HTTPSUrl, Stdlib::HTTPUrl, Stdlib::Absolutepath]
   $repo_gpgkey = 'https://yum.osc.edu/ondemand/RPM-GPG-KEY-ondemand-SHA512',
-  String $repo_proxy = '_none_',
+  Optional[String[1]] $repo_proxy = undef,
   Integer[1,99] $repo_priority = 99,
   String $repo_exclude = 'absent',
   Boolean $manage_dependency_repos = true,

--- a/manifests/repo/rpm.pp
+++ b/manifests/repo/rpm.pp
@@ -22,6 +22,7 @@ class openondemand::repo::rpm {
     metadata_expire => '1',
     priority        => $openondemand::repo_priority,
     exclude         => $openondemand::repo_exclude,
+    proxy           => $openondemand::repo_proxy,
   }
 
   yumrepo { 'ondemand-web-nightly':
@@ -34,6 +35,7 @@ class openondemand::repo::rpm {
     gpgkey          => $openondemand::repo_gpgkey,
     metadata_expire => '1',
     priority        => $openondemand::repo_priority,
+    proxy           => $openondemand::repo_proxy,
   }
 
   # Work around a bug where 'dnf module list' is not executed with -y


### PR DESCRIPTION
We have a secure environment that requires proxy to get out for dnf repos.  This adds the option to set a proxy for the OnDemand repo.