### PR TITLE
Support Puppet 8, Drop Puppet 6 support, update dependencies

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -16,15 +16,20 @@ fixtures:
       repo: puppetlabs/vcsrepo
     apache:
       repo: puppetlabs/apache
-    sudo:
-      repo: saz/sudo
+    # TODO: Once something newer than 7.0.2 released
+    #sudo:
+    #  repo: saz/sudo
     augeasproviders_core:
-      repo: herculesteam/augeasproviders_core
+      repo: puppet/augeasproviders_core
     augeasproviders_shellvar:
-      repo: herculesteam/augeasproviders_shellvar
+      repo: puppet/augeasproviders_shellvar
     systemd:
       repo: puppet/systemd
     logrotate:
       repo: puppet/logrotate
+  # TODO: Remove once something newer than 7.0.2 released
+  repositories:
+    sudo:
+      repo: https://github.com/saz/puppet-sudo.git
   symlinks:
     openondemand: "#{source_dir}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,18 +18,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: 2.5.9
-            puppet: 6
+          - ruby: 2.7.7
+            puppet: 7
             fixtures: .fixtures.yml
             allow_failure: false
-          - ruby: 2.7.6
-            puppet: 7
+          - ruby: 3.2.2
+            puppet: 8
             fixtures: .fixtures.yml
             allow_failure: false
     env:
       BUNDLE_WITHOUT: system_tests:release
       PUPPET_GEM_VERSION: "~> ${{ matrix.puppet }}.0"
-      FACTER_GEM_VERSION: "< 4.0"
       FIXTURES_YML: ${{ matrix.fixtures }}
     name: Puppet ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
     steps:
@@ -57,8 +56,8 @@ jobs:
           - "ubuntu-2004"
           - "ubuntu-2204"
         puppet:
-          - "puppet6"
           - "puppet7"
+          - "puppet8"
     env:
       BUNDLE_WITHOUT: development:release
       BEAKER_debug: true

--- a/.sync.yml
+++ b/.sync.yml
@@ -13,8 +13,8 @@ Rakefile:
         - ubuntu-2004
         - ubuntu-2204
       puppet:
-        - puppet6
         - puppet7
+        - puppet8
 .gitlab-ci.yml:
   delete: true
 appveyor.yml:

--- a/metadata.json
+++ b/metadata.json
@@ -14,23 +14,23 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 6.0.0 < 9.0.0"
+      "version_requirement": ">= 6.0.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/apache",
-      "version_requirement": ">= 5.2.0 < 7.0.0"
+      "version_requirement": ">= 5.2.0 < 11.0.0"
     },
     {
       "name": "puppetlabs/vcsrepo",
-      "version_requirement": ">= 1.3.0 < 6.0.0"
+      "version_requirement": ">= 1.3.0 < 7.0.0"
     },
     {
       "name": "saz/sudo",
       "version_requirement": ">= 3.0.0 <8.0.0"
     },
     {
-      "name": "herculesteam/augeasproviders_shellvar",
-      "version_requirement": ">= 2.0.0 <5.0.0"
+      "name": "puppet/augeasproviders_shellvar",
+      "version_requirement": ">= 2.0.0 <6.0.0"
     },
     {
       "name": "puppet/logrotate",
@@ -38,7 +38,7 @@
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 0.4.0 <4.0.0"
+      "version_requirement": ">= 0.4.0 <5.0.0"
     },
     {
       "name": "puppet/epel",
@@ -85,7 +85,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.1.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
   "tags": [
@@ -95,5 +95,5 @@
   ],
   "pdk-version": "2.1.0",
   "template-url": "https://github.com/treydock/pdk-templates.git#master",
-  "template-ref": "heads/master-0-gbfcd6dd"
+  "template-ref": "heads/master-0-gcb8e84f"
 }

--- a/spec/default_module_facts.yml
+++ b/spec/default_module_facts.yml
@@ -1,3 +1,4 @@
 ---
 root_home: /root
 sudoversion: '1.8.6p7'
+service_provider: systemd

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ default_fact_files.each do |f|
   next unless File.exist?(f) && File.readable?(f) && File.size?(f)
 
   begin
-    default_facts.merge!(YAML.safe_load(File.read(f), [], [], true))
+    default_facts.merge!(YAML.safe_load(File.read(f)))
   rescue StandardError => e
     RSpec.configuration.reporter.message "WARNING: Unable to load #{f}: #{e}"
   end

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -2,15 +2,3 @@
 
 dir = __dir__
 Dir["#{dir}/shared_examples/**/*.rb"].sort.each { |f| require f }
-
-require 'rspec-puppet-facts'
-include RspecPuppetFacts # rubocop:disable Style/MixinUsage
-
-add_custom_fact :service_provider, ->(_os, facts) {
-  case facts[:operatingsystemmajrelease]
-  when '6'
-    'redhat'
-  else
-    'systemd'
-  end
-}


### PR DESCRIPTION
* Support puppetlabs/apt 9.x
* Support puppetlabs/apache 10.x
* Support puppetlabs/vcsrepo 6.x
* Support puppet/augeasproviders_shellvar 5.x
* Support puppet/systemd 4.x