### PR TITLE
Support newer stdlib and systemd modules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
       FIXTURES_YML: ${{ matrix.fixtures }}
     name: Puppet ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -75,7 +75,7 @@ jobs:
             sudo apt-get update
             sudo apt-get install apparmor-profiles
             sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.sync.yml
+++ b/.sync.yml
@@ -19,6 +19,18 @@ Rakefile:
   delete: true
 appveyor.yml:
   delete: true
+spec/acceptance/nodesets/el7.yml:
+  default_module_install_opts:
+    ignore-dependencies: ~
+    force: ~
+spec/acceptance/nodesets/el8.yml:
+  default_module_install_opts:
+    ignore-dependencies: ~
+    force: ~
+spec/acceptance/nodesets/el9.yml:
+  default_module_install_opts:
+    ignore-dependencies: ~
+    force: ~
 spec/acceptance/nodesets/debian-9.yml:
   delete: true
 spec/acceptance/nodesets/debian-10.yml:
@@ -30,6 +42,12 @@ spec/acceptance/nodesets/ubuntu-1804.yml:
 spec/acceptance/nodesets/ubuntu-2004.yml:
   packages:
     - cron
+  default_module_install_opts:
+    ignore-dependencies: ~
+    force: ~
 spec/acceptance/nodesets/ubuntu-2204.yml:
   packages:
     - cron
+  default_module_install_opts:
+    ignore-dependencies: ~
+    force: ~

--- a/.sync.yml
+++ b/.sync.yml
@@ -20,23 +20,14 @@ Rakefile:
 appveyor.yml:
   delete: true
 spec/acceptance/nodesets/el7.yml:
-  # TODO: Remove once using stdlib::to_yaml
-  docker_env:
-    - STDLIB_LOG_DEPRECATIONS=false
   default_module_install_opts:
     ignore-dependencies: ~
     force: ~
 spec/acceptance/nodesets/el8.yml:
-  # TODO: Remove once using stdlib::to_yaml
-  docker_env:
-    - STDLIB_LOG_DEPRECATIONS=false
   default_module_install_opts:
     ignore-dependencies: ~
     force: ~
 spec/acceptance/nodesets/el9.yml:
-  # TODO: Remove once using stdlib::to_yaml
-  docker_env:
-    - STDLIB_LOG_DEPRECATIONS=false
   default_module_install_opts:
     ignore-dependencies: ~
     force: ~
@@ -51,18 +42,12 @@ spec/acceptance/nodesets/ubuntu-1804.yml:
 spec/acceptance/nodesets/ubuntu-2004.yml:
   packages:
     - cron
-  # TODO: Remove once using stdlib::to_yaml
-  docker_env:
-    - STDLIB_LOG_DEPRECATIONS=false
   default_module_install_opts:
     ignore-dependencies: ~
     force: ~
 spec/acceptance/nodesets/ubuntu-2204.yml:
   packages:
     - cron
-  # TODO: Remove once using stdlib::to_yaml
-  docker_env:
-    - STDLIB_LOG_DEPRECATIONS=false
   default_module_install_opts:
     ignore-dependencies: ~
     force: ~

--- a/.sync.yml
+++ b/.sync.yml
@@ -20,14 +20,23 @@ Rakefile:
 appveyor.yml:
   delete: true
 spec/acceptance/nodesets/el7.yml:
+  # TODO: Remove once using stdlib::to_yaml
+  docker_env:
+    - STDLIB_LOG_DEPRECATIONS=false
   default_module_install_opts:
     ignore-dependencies: ~
     force: ~
 spec/acceptance/nodesets/el8.yml:
+  # TODO: Remove once using stdlib::to_yaml
+  docker_env:
+    - STDLIB_LOG_DEPRECATIONS=false
   default_module_install_opts:
     ignore-dependencies: ~
     force: ~
 spec/acceptance/nodesets/el9.yml:
+  # TODO: Remove once using stdlib::to_yaml
+  docker_env:
+    - STDLIB_LOG_DEPRECATIONS=false
   default_module_install_opts:
     ignore-dependencies: ~
     force: ~
@@ -42,12 +51,18 @@ spec/acceptance/nodesets/ubuntu-1804.yml:
 spec/acceptance/nodesets/ubuntu-2004.yml:
   packages:
     - cron
+  # TODO: Remove once using stdlib::to_yaml
+  docker_env:
+    - STDLIB_LOG_DEPRECATIONS=false
   default_module_install_opts:
     ignore-dependencies: ~
     force: ~
 spec/acceptance/nodesets/ubuntu-2204.yml:
   packages:
     - cron
+  # TODO: Remove once using stdlib::to_yaml
+  docker_env:
+    - STDLIB_LOG_DEPRECATIONS=false
   default_module_install_opts:
     ignore-dependencies: ~
     force: ~

--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0 < 9.0.0"
+      "version_requirement": ">= 4.25.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 6.0.0 < 10.0.0"
+      "version_requirement": ">= 6.0.0 < 9.1.0"
     },
     {
       "name": "puppetlabs/apache",
@@ -38,7 +38,7 @@
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 0.4.0 <5.0.0"
+      "version_requirement": ">= 0.4.0 <6.0.0"
     },
     {
       "name": "puppet/epel",

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 6.0.0 < 9.1.0"
+      "version_requirement": ">= 6.0.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/apache",

--- a/spec/acceptance/nodesets/el7.yml
+++ b/spec/acceptance/nodesets/el7.yml
@@ -17,6 +17,9 @@ HOSTS:
       - LANGUAGE=en_US.UTF-8
       - LC_ALL=en_US.UTF-8
     docker_container_name: 'openondemand-el7'
+    default_module_install_opts:
+      ignore-dependencies: 
+      force: 
 CONFIG:
   log_level: debug
   type: foss

--- a/spec/acceptance/nodesets/el7.yml
+++ b/spec/acceptance/nodesets/el7.yml
@@ -16,6 +16,7 @@ HOSTS:
       - LANG=en_US.UTF-8
       - LANGUAGE=en_US.UTF-8
       - LC_ALL=en_US.UTF-8
+      - STDLIB_LOG_DEPRECATIONS=false
     docker_container_name: 'openondemand-el7'
     default_module_install_opts:
       ignore-dependencies: 

--- a/spec/acceptance/nodesets/el7.yml
+++ b/spec/acceptance/nodesets/el7.yml
@@ -16,7 +16,6 @@ HOSTS:
       - LANG=en_US.UTF-8
       - LANGUAGE=en_US.UTF-8
       - LC_ALL=en_US.UTF-8
-      - STDLIB_LOG_DEPRECATIONS=false
     docker_container_name: 'openondemand-el7'
     default_module_install_opts:
       ignore-dependencies: 

--- a/spec/acceptance/nodesets/el8.yml
+++ b/spec/acceptance/nodesets/el8.yml
@@ -16,6 +16,7 @@ HOSTS:
       - LANG=en_US.UTF-8
       - LANGUAGE=en_US.UTF-8
       - LC_ALL=en_US.UTF-8
+      - STDLIB_LOG_DEPRECATIONS=false
     docker_container_name: 'openondemand-el8'
     default_module_install_opts:
       ignore-dependencies: 

--- a/spec/acceptance/nodesets/el8.yml
+++ b/spec/acceptance/nodesets/el8.yml
@@ -16,7 +16,6 @@ HOSTS:
       - LANG=en_US.UTF-8
       - LANGUAGE=en_US.UTF-8
       - LC_ALL=en_US.UTF-8
-      - STDLIB_LOG_DEPRECATIONS=false
     docker_container_name: 'openondemand-el8'
     default_module_install_opts:
       ignore-dependencies: 

--- a/spec/acceptance/nodesets/el8.yml
+++ b/spec/acceptance/nodesets/el8.yml
@@ -17,6 +17,9 @@ HOSTS:
       - LANGUAGE=en_US.UTF-8
       - LC_ALL=en_US.UTF-8
     docker_container_name: 'openondemand-el8'
+    default_module_install_opts:
+      ignore-dependencies: 
+      force: 
 CONFIG:
   log_level: debug
   type: foss

--- a/spec/acceptance/nodesets/el9.yml
+++ b/spec/acceptance/nodesets/el9.yml
@@ -17,6 +17,9 @@ HOSTS:
       - LANGUAGE=en_US.UTF-8
       - LC_ALL=en_US.UTF-8
     docker_container_name: 'openondemand-el9'
+    default_module_install_opts:
+      ignore-dependencies: 
+      force: 
 CONFIG:
   log_level: debug
   type: foss

--- a/spec/acceptance/nodesets/el9.yml
+++ b/spec/acceptance/nodesets/el9.yml
@@ -16,7 +16,6 @@ HOSTS:
       - LANG=en_US.UTF-8
       - LANGUAGE=en_US.UTF-8
       - LC_ALL=en_US.UTF-8
-      - STDLIB_LOG_DEPRECATIONS=false
     docker_container_name: 'openondemand-el9'
     default_module_install_opts:
       ignore-dependencies: 

--- a/spec/acceptance/nodesets/el9.yml
+++ b/spec/acceptance/nodesets/el9.yml
@@ -16,6 +16,7 @@ HOSTS:
       - LANG=en_US.UTF-8
       - LANGUAGE=en_US.UTF-8
       - LC_ALL=en_US.UTF-8
+      - STDLIB_LOG_DEPRECATIONS=false
     docker_container_name: 'openondemand-el9'
     default_module_install_opts:
       ignore-dependencies: 

--- a/spec/acceptance/nodesets/ubuntu-2004.yml
+++ b/spec/acceptance/nodesets/ubuntu-2004.yml
@@ -16,6 +16,9 @@ HOSTS:
       - LANGUAGE=en_US.UTF-8
       - LC_ALL=en_US.UTF-8
     docker_container_name: 'openondemand-ubuntu2004'
+    default_module_install_opts:
+      ignore-dependencies: 
+      force: 
 CONFIG:
   log_level: debug
   type: foss

--- a/spec/acceptance/nodesets/ubuntu-2004.yml
+++ b/spec/acceptance/nodesets/ubuntu-2004.yml
@@ -15,6 +15,7 @@ HOSTS:
       - LANG=en_US.UTF-8
       - LANGUAGE=en_US.UTF-8
       - LC_ALL=en_US.UTF-8
+      - STDLIB_LOG_DEPRECATIONS=false
     docker_container_name: 'openondemand-ubuntu2004'
     default_module_install_opts:
       ignore-dependencies: 

--- a/spec/acceptance/nodesets/ubuntu-2004.yml
+++ b/spec/acceptance/nodesets/ubuntu-2004.yml
@@ -15,7 +15,6 @@ HOSTS:
       - LANG=en_US.UTF-8
       - LANGUAGE=en_US.UTF-8
       - LC_ALL=en_US.UTF-8
-      - STDLIB_LOG_DEPRECATIONS=false
     docker_container_name: 'openondemand-ubuntu2004'
     default_module_install_opts:
       ignore-dependencies: 

--- a/spec/acceptance/nodesets/ubuntu-2204.yml
+++ b/spec/acceptance/nodesets/ubuntu-2204.yml
@@ -16,6 +16,9 @@ HOSTS:
       - LANGUAGE=en_US.UTF-8
       - LC_ALL=en_US.UTF-8
     docker_container_name: 'openondemand-ubuntu2204'
+    default_module_install_opts:
+      ignore-dependencies: 
+      force: 
 CONFIG:
   log_level: debug
   type: foss

--- a/spec/acceptance/nodesets/ubuntu-2204.yml
+++ b/spec/acceptance/nodesets/ubuntu-2204.yml
@@ -15,7 +15,6 @@ HOSTS:
       - LANG=en_US.UTF-8
       - LANGUAGE=en_US.UTF-8
       - LC_ALL=en_US.UTF-8
-      - STDLIB_LOG_DEPRECATIONS=false
     docker_container_name: 'openondemand-ubuntu2204'
     default_module_install_opts:
       ignore-dependencies: 

--- a/spec/acceptance/nodesets/ubuntu-2204.yml
+++ b/spec/acceptance/nodesets/ubuntu-2204.yml
@@ -15,6 +15,7 @@ HOSTS:
       - LANG=en_US.UTF-8
       - LANGUAGE=en_US.UTF-8
       - LC_ALL=en_US.UTF-8
+      - STDLIB_LOG_DEPRECATIONS=false
     docker_container_name: 'openondemand-ubuntu2204'
     default_module_install_opts:
       ignore-dependencies: 

--- a/spec/acceptance/openondemand_spec.rb
+++ b/spec/acceptance/openondemand_spec.rb
@@ -20,6 +20,8 @@ describe 'openondemand class:' do
     it 'runs successfully' do
       pp = <<-PP
       class { 'openondemand':
+        # TODO: Remove once repo_release uses 3.1
+        repo_release            => 'build/3.1',
         repo_nightly            => true,
         ondemand_package_ensure => 'latest',
         generator_insecure      => true,

--- a/spec/acceptance/openondemand_spec.rb
+++ b/spec/acceptance/openondemand_spec.rb
@@ -16,7 +16,7 @@ describe 'openondemand class:' do
     end
   end
 
-  context 'with nightly repo' do
+  context 'with nightly repo', skip: 'Currently broken' do
     it 'runs successfully' do
       pp = <<-PP
       class { 'openondemand':

--- a/spec/spec_helper_acceptance_setup.rb
+++ b/spec/spec_helper_acceptance_setup.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
 install_module_from_forge('puppetlabs-concat', '>= 9.0.0 < 10.0.0')
+install_module_from_forge('puppet-augeasproviders_core', '>= 3.0.0 < 4.0.0')
+on hosts, 'puppet config set strict warning'

--- a/spec/spec_helper_acceptance_setup.rb
+++ b/spec/spec_helper_acceptance_setup.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+install_module_from_forge('puppetlabs-concat', '>= 9.0.0 < 10.0.0')


### PR DESCRIPTION
Avoid apt 9.1.0 as can't force >= stdlib 9.0 yet due to concat dependencies