### PR TITLE
Removed Nginx stage ondemand title default value

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -752,7 +752,7 @@ Data type: `String`
 
 nginx_stage.yml ondemand_title
 
-Default value: `'Open OnDemand'`
+Default value: `undef`
 
 ##### <a name="-openondemand--nginx_stage_pun_custom_env"></a>`nginx_stage_pun_custom_env`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -318,7 +318,7 @@ class openondemand (
   # nginx_stage configs
   String $nginx_stage_clean_cron_schedule = '0 */2 * * *',
   String $nginx_stage_ondemand_portal = 'ondemand',
-  String $nginx_stage_ondemand_title  = 'Open OnDemand',
+  Optional[String] $nginx_stage_ondemand_title  = undef,
   Hash $nginx_stage_pun_custom_env = {},
   Openondemand::Nginx_stage_namespace_config $nginx_stage_app_root  = {},
   String $nginx_stage_scl_env = 'ondemand',

--- a/templates/nginx_stage.yml.erb
+++ b/templates/nginx_stage.yml.erb
@@ -29,7 +29,7 @@ ondemand_portal: '<%= scope['openondemand::nginx_stage_ondemand_portal'] -%>'
 #
 #ondemand_title: null
 <% if scope['openondemand::nginx_stage_ondemand_title'] -%>
-ondemand_title: '<%= scope['openondemand::nginx_stage_ondemand_title'] -%>'
+ondemand_title: '<%= scope['openondemand::nginx_stage_ondemand_title'] %>'
 <% end -%>
 
 # Custom environment variables to set for the PUN environment

--- a/templates/nginx_stage.yml.erb
+++ b/templates/nginx_stage.yml.erb
@@ -28,7 +28,7 @@ ondemand_portal: '<%= scope['openondemand::nginx_stage_ondemand_portal'] -%>'
 # NB: If this is not set then most apps will use default title "Open OnDemand"
 #
 #ondemand_title: null
-<% if scope['openondemand::nginx_stage_ondemand_title'] != nil -%>
+<% if scope['openondemand::nginx_stage_ondemand_title'] -%>
 ondemand_title: '<%= scope['openondemand::nginx_stage_ondemand_title'] -%>'
 <% end -%>
 

--- a/templates/nginx_stage.yml.erb
+++ b/templates/nginx_stage.yml.erb
@@ -28,7 +28,9 @@ ondemand_portal: '<%= scope['openondemand::nginx_stage_ondemand_portal'] -%>'
 # NB: If this is not set then most apps will use default title "Open OnDemand"
 #
 #ondemand_title: null
+<% if scope['openondemand::nginx_stage_ondemand_title'] != nil -%>
 ondemand_title: '<%= scope['openondemand::nginx_stage_ondemand_title'] -%>'
+<% end -%>
 
 # Custom environment variables to set for the PUN environment
 # Below is an example of the use for setting env vars.


### PR DESCRIPTION
Removed Nginx stage ondemand title default value for 2 reasons.
 - This is not needed as the dashboard application already defaults to 'Open OnDemand'.
 - The dashboard title value cannot be overridden within user profiles as the ENV value is set and takes precedence.