### PR TITLE
Parameter for apache_user, Ubuntu uses www-data, not apache

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -71,6 +71,7 @@ The following parameters are available in the `openondemand` class:
 * [`install_apps`](#-openondemand--install_apps)
 * [`declare_apache`](#-openondemand--declare_apache)
 * [`apache_scls`](#-openondemand--apache_scls)
+* [`apache_user`](#-openondemand--apache_user)
 * [`generator_insecure`](#-openondemand--generator_insecure)
 * [`listen_addr_port`](#-openondemand--listen_addr_port)
 * [`servername`](#-openondemand--servername)
@@ -294,6 +295,14 @@ Data type: `String`
 SCLs to load when starting Apache service
 
 Default value: `'httpd24'`
+
+##### <a name="-openondemand--apache_user"></a>`apache_user`
+
+Data type: `String`
+
+Name for Apache user
+
+Default value: `'apache'`
 
 ##### <a name="-openondemand--generator_insecure"></a>`generator_insecure`
 

--- a/data/os/Ubuntu.yaml
+++ b/data/os/Ubuntu.yaml
@@ -1,0 +1,2 @@
+---
+openondemand::apache_user: www-data

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -8,6 +8,8 @@ defaults:  # Used for any hierarchy level that omits these keys.
 hierarchy:
   - name: 'os family - os major version'
     path: "os/%{facts.os.family}/%{facts.os.release.major}.yaml"
+  - name: 'os name'
+    path: "os/%{facts.os.name}.yaml"
   - name: 'os family'
     path: "os/%{facts.os.family}.yaml"
   - name: 'common'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,8 @@
 #   Boolean that determines if apache is declared or included
 # @param apache_scls
 #   SCLs to load when starting Apache service
+# @param apache_user
+#   Name of Apache user
 # @param generator_insecure
 #   Run ood-portal-generator with --insecure flag
 #   This is needed if you wish to use default ood@localhost user or
@@ -252,6 +254,7 @@ class openondemand (
   # Apache
   Boolean $declare_apache = true,
   String $apache_scls = 'httpd24',
+  String $apache_user = 'apache',
 
   # ood_portal.yml
   Boolean $generator_insecure = false,

--- a/templates/sudo.erb
+++ b/templates/sudo.erb
@@ -1,5 +1,5 @@
-Defaults:apache !requiretty, !authenticate
-Defaults:apache env_keep += "NGINX_STAGE_* OOD_*"
-apache ALL=(ALL) NOPASSWD: <%= scope['openondemand::nginx_stage_cmd'] %>
+Defaults:<%= scope['openondemand::apache_user'] %> !requiretty, !authenticate
+Defaults:<%= scope['openondemand::apache_user'] %> env_keep += "NGINX_STAGE_* OOD_*"
+<%= scope['openondemand::apache_user'] %> ALL=(ALL) NOPASSWD: <%= scope['openondemand::nginx_stage_cmd'] %>
 Cmnd_Alias KUBECTL = <%= scope['openondemand::kubectl_path'] %>
 Defaults!KUBECTL !syslog


### PR DESCRIPTION
Added a parameter for the apache user name, as Ubuntu uses a different default name: www-data
needed for the sudoers config file