### PR TITLE
Added LDAP Apache modules as default in the Apache configuration

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -57,6 +57,10 @@ class openondemand::apache {
   include apache::mod::proxy_http
   include apache::mod::proxy_connect
   include apache::mod::proxy_wstunnel
+
+  # ldap should probably be a default module.
+  include apache::mod::ldap
+  include apache::mod::authnz_ldap
   if $openondemand::auth_type == 'CAS' {
     include apache::mod::auth_cas
   }


### PR DESCRIPTION
Bill from the IQSS team was reviewing our puppet configuration for OnDemand and realized that we were including the LDAP apache modules within our configuration.

Should the LDAP modules be part of the default modules added by the Apache config in OnDemand?