### PR TITLE
Added support to add module files into the OnDemand public folder

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -190,6 +190,17 @@ class openondemand::config {
     }
   }
 
+  $openondemand::public_files_source_paths.each |$path| {
+    $basename = basename($path)
+    file { "${openondemand::public_root}/${basename}":
+      ensure  => 'file',
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      source  => $path,
+    }
+  }
+
   file { '/etc/ood/config/clusters.d':
     ensure  => 'directory',
     owner   => 'root',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -193,11 +193,11 @@ class openondemand::config {
   $openondemand::public_files_source_paths.each |$path| {
     $basename = basename($path)
     file { "${openondemand::public_root}/${basename}":
-      ensure  => 'file',
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0644',
-      source  => $path,
+      ensure => 'file',
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0644',
+      source => $path,
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -225,6 +225,8 @@
 #   Source for aouncements config, not used if `apps_config_repo` is defined
 # @param public_files_repo_paths
 #   Path to public files in apps config Git repo
+# @param public_files_source_paths
+#   Path to the source for public files
 # @param manage_logrotate
 #   Boolean that allows disabling management of logrotate
 #
@@ -367,6 +369,7 @@ class openondemand (
   Optional[String] $locales_config_source = undef,
   Optional[String] $announcements_config_source = undef,
   Array $public_files_repo_paths = [],
+  Array $public_files_source_paths = [],
 
   # Disable functionality
   Boolean $manage_logrotate = true,


### PR DESCRIPTION
We store public files within the Puppet configuration. We would like to use this location to configure the public folder.

This change adds support to specify a list of files to add the public folder.

```yaml
openondemand::public_files_source_paths:
  - "puppet:///modules/profile/openondemand/common/logo_small_fasrc.png"
  - "puppet:///modules/profile/openondemand/common/rc-logo-text_2017_sm.png"
```