### PR TITLE
Don't wrap yaml lines for confs

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -36,7 +36,7 @@ define openondemand::conf (
   if $data {
     $_content = join([
         '# File managed by Puppet - DO NOT EDIT',
-        to_yaml($data, {line_width => -1}),
+        to_yaml($data, { 'line_width' => -1 }),
         '',
     ], "\n")
   } elsif $content_template {

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -36,7 +36,7 @@ define openondemand::conf (
   if $data {
     $_content = join([
         '# File managed by Puppet - DO NOT EDIT',
-        to_yaml($data),
+        to_yaml($data, {line_width => -1}),
         '',
     ], "\n")
   } elsif $content_template {


### PR DESCRIPTION
The default behavior of `to_yaml` is to wrap lines to 80 characters, but confs can be erb templates that can exceed that and get broken by the forced line wrap. For example, this hiera:

```
openondemand::confs:
  support_ticket:
    template: true
    data:
      support_ticket:
        email:
          to: help@msi.umn.edu
          delivery_method: sendmail

        attributes:
          username:
            value: "<%= CurrentUser.name %>"
            readonly: true
          email:
            value: "<%= %x{ldapsearch -x uid=#{CurrentUser.name} mail | grep -Po 'mail: \\K[^\\s]+' } %>"
```
email.value is linewrapped when processed through `to_yaml`, breaking the ERB template.

The fix in this PR is to not line wrap.

