### PR TITLE
Support OnDemand 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Manage [Open OnDemand](http://openondemand.org/) installation and configuration.
 
 The following are the versions of this module and the supported versions of Open OnDemand:
 
+* Module 7.x supports OnDemand 4.0 and 3.1
 * Module 5.x and 6.x supports Open OnDemand 3.1 and 3.0
 * Module 3.x and 4.x supports Open OnDemand 3.0
 * Module 2.x supports Open OnDemand 2.x
@@ -34,12 +35,12 @@ All configuration can be done through the `openondemand` class. Example configur
 include openondemand
 ```
 
-Install specific versions of OnDemand from 3.0 repo with OpenID Connect support.
+Install specific versions of OnDemand from 3.1 repo with OpenID Connect support.
 
 ```yaml
-openondemand::repo_release: '3.0'
-openondemand::ondemand_package_ensure: "3.0.0-1.el7"
-openondemand::mod_auth_openidc_ensure: "3.4.5-1.el7"
+openondemand::repo_release: '3.1'
+openondemand::ondemand_package_ensure: "3.1.0-1.el9"
+openondemand::mod_auth_openidc_ensure: "3.4.5-1.el9"
 ```
 
 Configure OnDemand SSL certs

--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -4,12 +4,6 @@ class openondemand::apache {
   assert_private()
 
   if $openondemand::declare_apache {
-    if $openondemand::scl_apache {
-      class { 'apache::version':
-        scl_httpd_version => '2.4',
-        scl_php_version   => '7.0',
-      }
-    }
     class { 'apache':
       default_vhost => false,
     }
@@ -17,16 +11,10 @@ class openondemand::apache {
     contain apache
   }
 
-  if $openondemand::scl_apache {
-    $package_prefix = 'httpd24-'
-  } else {
-    $package_prefix = ''
-  }
-
   if $facts['os']['family'] == 'RedHat' {
-    $session_package = "${package_prefix}mod_session"
-    $proxy_html_package = "${package_prefix}mod_proxy_html"
-    $openidc_package = "${package_prefix}mod_auth_openidc"
+    $session_package = 'mod_session'
+    $proxy_html_package = 'mod_proxy_html'
+    $openidc_package = 'mod_auth_openidc'
   } else {
     $session_package = undef
     $proxy_html_package = undef
@@ -68,16 +56,6 @@ class openondemand::apache {
     apache::mod { 'auth_openidc':
       package        => $openidc_package,
       package_ensure => $openondemand::mod_auth_openidc_ensure,
-    }
-  }
-
-  if $openondemand::scl_apache {
-    shellvar { 'HTTPD24_HTTPD_SCLS_ENABLED':
-      ensure  => 'present',
-      target  => '/opt/rh/httpd24/service-environment',
-      value   => $openondemand::apache_scls,
-      require => Package['httpd'],
-      notify  => Class['Apache::Service'],
     }
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -315,12 +315,12 @@ class openondemand::config {
     }
   }
 
+  # TODO: Add back once better way to customize this file
   file { '/etc/ood/profile':
-    ensure  => 'file',
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    content => template('openondemand/profile.erb'),
+    ensure => 'absent',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
   }
 
   sudo::conf { 'ood':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,8 +38,6 @@
 #   Boolean that determines if apache is declared or included
 # @param apache_user
 #   Name of the Apache user
-# @param apache_scls
-#   SCLs to load when starting Apache service
 # @param generator_insecure
 #   Run ood-portal-generator with --insecure flag
 #   This is needed if you wish to use default ood@localhost user or
@@ -58,6 +56,8 @@
 #   ood_portal.yml logroot
 # @param use_rewrites
 #   ood_portal.yml use_rewrites
+# @param http_redirect_host
+#   ood_portal.yml http_redirect_host
 # @param use_maintenance
 #   ood_portal.yml use_maintenance
 # @param maintenance_ip_allowlist
@@ -167,8 +167,6 @@
 #   nginx_stage.yml pun_custom_env
 # @param nginx_stage_app_root
 #   nginx_stage.yml app_root
-# @param nginx_stage_scl_env
-#   nginx_stage.yml scl_env
 # @param nginx_stage_app_request_regex
 #   nginx_stage.yml app_request_regex
 # @param nginx_stage_min_uid
@@ -246,7 +244,7 @@
 #
 class openondemand (
   # repos
-  String $repo_release = '3.1',
+  String $repo_release = '4.0',
   Variant[Stdlib::HTTPSUrl, Stdlib::HTTPUrl]
   $repo_baseurl_prefix = 'https://yum.osc.edu/ondemand',
   Variant[Stdlib::HTTPSUrl, Stdlib::HTTPUrl, Stdlib::Absolutepath]
@@ -271,7 +269,6 @@ class openondemand (
   # Apache
   Boolean $declare_apache = true,
   String[1] $apache_user = 'apache',
-  String $apache_scls = 'httpd24',
 
   # ood_portal.yml
   Boolean $generator_insecure = false,
@@ -282,6 +279,7 @@ class openondemand (
   Boolean $disable_logs = false,
   String  $logroot = 'logs',
   Boolean $use_rewrites = true,
+  String $http_redirect_host = '%{HTTP_HOST}',
   Boolean $use_maintenance = true,
   Array $maintenance_ip_allowlist = [],
   Optional[String] $maintenance_source = undef,
@@ -344,7 +342,6 @@ class openondemand (
   Optional[String] $nginx_stage_ondemand_title  = undef,
   Hash $nginx_stage_pun_custom_env = {},
   Openondemand::Nginx_stage_namespace_config $nginx_stage_app_root  = {},
-  String $nginx_stage_scl_env = 'ondemand',
   Optional[Openondemand::Nginx_stage_namespace_config] $nginx_stage_app_request_regex = undef,
   Integer $nginx_stage_min_uid = 1000,
   Integer $nginx_stage_passenger_pool_idle_time = 300,
@@ -399,46 +396,23 @@ class openondemand (
   $osname = $facts.dig('os', 'name')
   $osmajor = $facts.dig('os', 'release', 'major')
 
-  $supported = ['RedHat-7','RedHat-8','RedHat-9','RedHat-2023','Debian-20.04','Debian-22.04','Debian-24.04','Debian-12']
+  $supported = ['RedHat-8','RedHat-9','RedHat-2023','Debian-20.04','Debian-22.04','Debian-24.04','Debian-12']
   $os = "${osfamily}-${osmajor}"
   if ! ($os in $supported) {
     fail("Unsupported OS: module ${module_name}. osfamily=${osfamily} osmajor=${osmajor} detected")
   }
 
-  # Handle unsupported distro and OnDemand combos
   if $repo_release == '3.1' {
-    if "${osfamily}-${osmajor}" == 'RedHat-7' {
-      fail('EL7 is not supported with OnDemand 3.1')
+    # Debian 12 and Ubuntu 24.04 in OnDemand 3.1 use OS NodeJS
+    if (String($openondemand::osmajor) in ['12', '24.04']) {
+      $nodejs = undef
+    } else {
+      $nodejs = '18'
     }
-  }
-  if $repo_release == '3.0' {
-    if "${osname}-${osmajor}" == 'Amazon-2023' {
-      fail('Amazon 2023 is not supported with OnDemand 3.0')
-    }
-    if "${osname}-${osmajor}" == 'Debian-12' {
-      fail('Debian 12 is not supported with OnDemand 3.0')
-    }
-    if "${osname}-${osmajor}" == 'Ubuntu-24.04' {
-      fail('Ubuntu 24.04 is not supported with OnDemand 3.0')
-    }
-  }
-
-  if versioncmp($osmajor, '7') <= 0 {
-    $scl_apache = true
-  } else {
-    $scl_apache = false
-  }
-
-  # EL9 only has these two versions at this time
-  if $repo_release == '3.0' and "${osfamily}-${osmajor}" == 'RedHat-9' {
-    $nodejs = 'absent'
-    $ruby = 'absent'
-  } elsif $repo_release == '3.0' {
-    $nodejs = '14'
-    $ruby = '3.0'
-  } else {
-    $nodejs = '18'
     $ruby = '3.1'
+  } else {
+    $nodejs = '20'
+    $ruby = '3.3'
   }
 
   if $selinux {
@@ -536,6 +510,7 @@ class openondemand (
     'disable_logs'                     => $disable_logs,
     'logroot'                          => $logroot,
     'use_rewrites'                     => $use_rewrites,
+    'http_redirect_host'               => $http_redirect_host,
     'use_maintenance'                  => $use_maintenance,
     'maintenance_ip_allowlist'         => $maintenance_ip_allowlist,
     'security_csp_frame_ancestors'     => $security_csp_frame_ancestors,

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -25,8 +25,7 @@ class openondemand::repo::apt {
     },
   }
 
-  # Debian 12 has NodeJS 18 in OS repos
-  if ! (String($openondemand::osmajor) in ['12', '24.04']) and $openondemand::nodejs == '18' {
+  if $openondemand::nodejs == '18' {
     apt::source { 'nodesource':
       ensure   => 'present',
       location => 'https://deb.nodesource.com/node_18.x',
@@ -39,15 +38,15 @@ class openondemand::repo::apt {
     }
   }
 
-  if $openondemand::nodejs == '14' {
+  if $openondemand::nodejs == '20' {
     apt::source { 'nodesource':
       ensure   => 'present',
-      location => 'https://deb.nodesource.com/node_14.x',
+      location => 'https://deb.nodesource.com/node_20.x',
       repos    => 'main',
-      release  => $facts['os']['distro']['codename'],
+      release  => 'nodistro',
       key      => {
-        'id'     => '9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280',
-        'source' => 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key',
+        'id'     => '6F71F525282841EEDAF851B42F59B5F99B1BE0B4',
+        'source' => 'https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key',
       },
     }
   }

--- a/manifests/repo/rpm.pp
+++ b/manifests/repo/rpm.pp
@@ -40,36 +40,16 @@ class openondemand::repo::rpm {
     module_hotfixes => $openondemand::repo_module_hotfixes,
   }
 
-  if versioncmp($openondemand::osmajor, '8') >= 0 {
-    # Work around a bug where 'dnf module list' is not executed with -y
-    exec { 'dnf makecache ondemand-web':
-      path        => '/usr/bin:/bin:/usr/sbin:/sbin',
-      command     => "dnf -q makecache -y --disablerepo='*' --enablerepo='ondemand-web'",
-      refreshonly => true,
-      subscribe   => Yumrepo['ondemand-web'],
-    }
+  # Work around a bug where 'dnf module list' is not executed with -y
+  exec { 'dnf makecache ondemand-web':
+    path        => '/usr/bin:/bin:/usr/sbin:/sbin',
+    command     => "dnf -q makecache -y --disablerepo='*' --enablerepo='ondemand-web'",
+    refreshonly => true,
+    subscribe   => Yumrepo['ondemand-web'],
   }
 
   if $openondemand::manage_epel {
     contain epel
-  }
-
-  if versioncmp($openondemand::osmajor, '7') == 0 and $openondemand::manage_dependency_repos {
-    case $facts['os']['name'] {
-      'RedHat': {
-        rh_repo { "rhel-server-rhscl-${openondemand::osmajor}-rpms":
-          ensure => 'present',
-        }
-      }
-      'CentOS': {
-        package { 'centos-release-scl':
-          ensure => 'installed',
-        }
-      }
-      default: {
-        # Do nothing
-      }
-    }
   }
 
   if String($openondemand::osmajor) in ['8', '9'] and $openondemand::manage_dependency_repos {

--- a/spec/shared_examples/repo_apt.rb
+++ b/spec/shared_examples/repo_apt.rb
@@ -4,7 +4,7 @@ shared_examples 'openondemand::repo::apt' do |facts|
   it do
     is_expected.to contain_apt__source('ondemand-web').with(
       ensure: 'present',
-      location: 'https://apt.osc.edu/ondemand/3.1/web/apt',
+      location: 'https://apt.osc.edu/ondemand/4.0/web/apt',
       repos: 'main',
       release: facts[:os]['distro']['codename'],
       key: {
@@ -27,37 +27,37 @@ shared_examples 'openondemand::repo::apt' do |facts|
     )
   end
 
-  if facts[:os]['release']['major'].to_i != 12 && facts[:os]['release']['major'].to_s != '24.04'
-    it do
-      is_expected.to contain_apt__source('nodesource').with(
-        ensure: 'present',
-        location: 'https://deb.nodesource.com/node_18.x',
-        repos: 'main',
-        release: 'nodistro',
-        key: {
-          'id' => '6F71F525282841EEDAF851B42F59B5F99B1BE0B4',
-          'source' => 'https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key',
-        },
-      )
-    end
-  else
-    it { is_expected.not_to contain_apt__source('nodesource') }
+  it do
+    is_expected.to contain_apt__source('nodesource').with(
+      ensure: 'present',
+      location: 'https://deb.nodesource.com/node_20.x',
+      repos: 'main',
+      release: 'nodistro',
+      key: {
+        'id' => '6F71F525282841EEDAF851B42F59B5F99B1BE0B4',
+        'source' => 'https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key',
+      },
+    )
   end
 
-  context 'when repo_release => 3.0', if: facts[:os]['release']['major'].to_i != 12 && facts[:os]['release']['major'].to_s != '24.04' do
-    let(:params) { { repo_release: '3.0' } }
+  context 'when repo_release => 3.1' do
+    let(:params) { { repo_release: '3.1' } }
 
-    it do
-      is_expected.to contain_apt__source('nodesource').with(
-        ensure: 'present',
-        location: 'https://deb.nodesource.com/node_14.x',
-        repos: 'main',
-        release: facts[:os]['distro']['codename'],
-        key: {
-          'id' => '9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280',
-          'source' => 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key',
-        },
-      )
+    if facts[:os]['release']['major'].to_i != 12 && facts[:os]['release']['major'].to_s != '24.04'
+      it do
+        is_expected.to contain_apt__source('nodesource').with(
+          ensure: 'present',
+          location: 'https://deb.nodesource.com/node_18.x',
+          repos: 'main',
+          release: 'nodistro',
+          key: {
+            'id' => '6F71F525282841EEDAF851B42F59B5F99B1BE0B4',
+            'source' => 'https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key',
+          },
+        )
+      end
+    else
+      it { is_expected.not_to contain_apt__source('nodesource') }
     end
   end
 

--- a/spec/spec_helper_acceptance_setup.rb
+++ b/spec/spec_helper_acceptance_setup.rb
@@ -5,16 +5,8 @@ install_module_from_forge('puppet-augeasproviders_core', '>= 3.0.0 < 4.0.0')
 on hosts, 'puppet config set strict warning'
 
 def supported_releases
-  osname = fact('os.name')
-  osfamily = fact('os.family')
-  osmajor = fact('os.release.major')
-  if ['Amazon-2023', 'Debian-12', 'Ubuntu-24.04'].include?("#{osname}-#{osmajor}")
-    ['3.1']
-  elsif "#{osfamily}-#{osmajor}" == 'RedHat-7'
-    ['3.0']
-  else
-    ['3.0', '3.1']
-  end
+  # TODO: Switch to '4.0' once that repo is released
+  ['3.1', 'build/4.0']
 end
 
 RSpec.configure do |c|

--- a/spec/spec_helper_acceptance_setup.rb
+++ b/spec/spec_helper_acceptance_setup.rb
@@ -5,8 +5,7 @@ install_module_from_forge('puppet-augeasproviders_core', '>= 3.0.0 < 4.0.0')
 on hosts, 'puppet config set strict warning'
 
 def supported_releases
-  # TODO: Switch to '4.0' once that repo is released
-  ['3.1', 'build/4.0']
+  ['3.1', '4.0']
 end
 
 RSpec.configure do |c|

--- a/templates/profile.erb
+++ b/templates/profile.erb
@@ -1,3 +1,0 @@
-# Source the required Software Collections packages into the environment in
-# which the per-user NGINX runs under
-source scl_source enable <%= scope['openondemand::nginx_stage_scl_env'] %>


### PR DESCRIPTION
* Support OnDemand 4.0 dependencies Fixes #166
* Change repo_release to default to '4.0'
* Remove apache_scls parameter
* Remove nginx_stage_scl_env parameter
* Add http_redirect_host parameter
* No longer support OnDemand 3.0
* Remove all references to SCL , Fixes #167