### PR TITLE
Added configuration to enable/disable maintenance with Puppet

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -95,11 +95,17 @@ class openondemand::config {
   }
 
   if $openondemand::maintenance_enabled != undef {
-    file { "/etc/ood/maintenance.enable":
-      ensure  => $openondemand::maintenance_enabled ? { true => 'file', false => 'absent' },
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0644',
+    if $openondemand::maintenance_enabled {
+      $maintenance_enable_ensure = 'file'
+    } else {
+      $maintenance_enable_ensure = 'absent'
+    }
+
+    file { '/etc/ood/maintenance.enable':
+      ensure => $openondemand::maintenance_enabled,
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0644',
     }
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -94,6 +94,15 @@ class openondemand::config {
     mode   => '0755',
   }
 
+  if $openondemand::maintenance_enabled != undef {
+    file { "/etc/ood/maintenance.enable":
+      ensure  => $openondemand::maintenance_enabled ? { true => 'file', false => 'absent' },
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+    }
+  }
+
   file { '/etc/ood/config':
     ensure => 'directory',
     owner  => 'root',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -94,19 +94,17 @@ class openondemand::config {
     mode   => '0755',
   }
 
-  if $openondemand::maintenance_enabled != undef {
-    if $openondemand::maintenance_enabled {
-      $maintenance_enable_ensure = 'file'
-    } else {
-      $maintenance_enable_ensure = 'absent'
-    }
+  if $openondemand::maintenance_enabled {
+    $maintenance_enable_ensure = 'file'
+  } else {
+    $maintenance_enable_ensure = 'absent'
+  }
 
-    file { '/etc/ood/maintenance.enable':
-      ensure => $openondemand::maintenance_enabled,
-      owner  => 'root',
-      group  => 'root',
-      mode   => '0644',
-    }
+  file { '/etc/ood/maintenance.enable':
+    ensure => $maintenance_enable_ensure,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
   }
 
   file { '/etc/ood/config':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,8 @@
 #   Source for maintenance index.html
 # @param maintenance_content
 #   Content for maintenance index.html
+# @param maintenance_enabled
+#   Enable maintenance mode in OOD
 # @param security_csp_frame_ancestors
 #   ood_portal.yml security_csp_frame_ancestors
 # @param security_strict_transport
@@ -286,6 +288,7 @@ class openondemand (
   Array $maintenance_ip_allowlist = [],
   Optional[String] $maintenance_source = undef,
   Optional[String] $maintenance_content = undef,
+  Optional[Boolean] $maintenance_enabled = undef,
   Optional[Variant[String, Boolean]] $security_csp_frame_ancestors = undef,
   Boolean $security_strict_transport = true,
   String $lua_root = '/opt/ood/mod_ood_proxy/lib',


### PR DESCRIPTION
As we manage all the OOD configuration and deployments with Puppet, we would like to enable/disable maintenance mode using a Puppet deployment.

This PR adds a new file resource to manage the `maintenace.enable` file.
I am using undef to make it backwards compatible with institutions managing this file manually.