### PR TITLE
vcsrepo: change `< 7.0.0` to `< 8.0.0`

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs/vcsrepo",
-      "version_requirement": ">= 5.4.0 <= 7.0.0"
+      "version_requirement": ">= 5.4.0 < 8.0.0"
     },
     {
       "name": "saz/sudo",

--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs/vcsrepo",
-      "version_requirement": ">= 5.4.0 < 7.0.0"
+      "version_requirement": ">= 5.4.0 <= 7.0.0"
     },
     {
       "name": "saz/sudo",


### PR DESCRIPTION
Allows to use the latest major version of the vcsrepo module
